### PR TITLE
fix(metadata): enforce registry semantics (required fields)

### DIFF
--- a/src/Cardano.Metadata/Services/MetadataDbService.cs
+++ b/src/Cardano.Metadata/Services/MetadataDbService.cs
@@ -16,10 +16,10 @@ public class MetadataDbService
 
         if (string.IsNullOrEmpty(token.Subject) ||
             string.IsNullOrEmpty(token.Name) ||
-            string.IsNullOrEmpty(token.Ticker) ||
+            string.IsNullOrEmpty(token.Description) ||
             token.Decimals < 0)
         {
-            logger.LogWarning("Invalid token data. Name, Ticker, Subject or Decimals cannot be null or empty.");
+            logger.LogWarning("Invalid token data. Subject, Name, Description required; Decimals must be non-negative if present.");
             return null;
         }
 
@@ -101,11 +101,12 @@ public class MetadataDbService
             return null;
         }
 
-        if (string.IsNullOrEmpty(updated.Name) ||
-           string.IsNullOrEmpty(updated.Ticker) ||
-           updated.Decimals < 0)
+        if (string.IsNullOrEmpty(updated.Subject) ||
+            string.IsNullOrEmpty(updated.Name) ||
+            string.IsNullOrEmpty(updated.Description) ||
+            updated.Decimals < 0)
         {
-            logger.LogWarning("Invalid token data. Name, Ticker, Subject or Decimals cannot be null or empty.");
+            logger.LogWarning("Invalid token data. Subject, Name, Description required; Decimals must be non-negative if present.");
             return null;
         }
 

--- a/src/Cardano.Metadata/Workers/GithubWorker.cs
+++ b/src/Cardano.Metadata/Workers/GithubWorker.cs
@@ -135,12 +135,17 @@ public class GithubWorker
 
         var subject = resp.Subject;
         var name = resp.Name?.Value;
-        var ticker = resp.Ticker?.Value;
+        var description = resp.Description?.Value;
+        var ticker = resp.Ticker?.Value ?? string.Empty; // optional
 
-        if (string.IsNullOrEmpty(subject) || string.IsNullOrEmpty(name) || string.IsNullOrEmpty(ticker))
+        if (string.IsNullOrEmpty(subject))
         {
-            logger.LogWarning("Invalid token data. Subject: {Subject}, Name: {Name}, Ticker: {Ticker}", 
-                subject ?? "null", name ?? "null", ticker ?? "null");
+            logger.LogWarning("Invalid token data. Missing subject; skipping.");
+            return null;
+        }
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(description))
+        {
+            logger.LogWarning("Invalid token data. Subject: {Subject}, Name: {Name}, Description: {Description}", subject, name ?? "null", description ?? "null");
             return null;
         }
 
@@ -157,7 +162,7 @@ public class GithubWorker
             PolicyId = subject.Length >= 56 ? subject[..56] : string.Empty,
             Name = name,
             Ticker = ticker,
-            Description = resp.Description?.Value,
+            Description = description,
             Url = resp.Url?.Value,
             Logo = resp.Logo?.Value,
             Policy = resp.Policy,


### PR DESCRIPTION
## Summary
Align validation with Cardano Foundation token registry semantics.

## Changes
- Require `subject`, `name`, and `description`.
- Keep `ticker`, `policy`, `url`, `logo` optional (insert even when missing).
- Validate `decimals` are non‑negative if present.

## Files
- `Workers/GithubWorker.cs`: map requires subject+name+description, allow empty ticker.
- `Services/MetadataDbService.cs`: enforce required fields during add/update.

## Verification
- Build: `dotnet build`
- Fresh sync: truncate tables, run app, confirm inserts (including entries without ticker).
